### PR TITLE
Add docs on how to initialize the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ load all environment varibles in `main.dart`
 import 'package:flutter_config/flutter_config.dart';
 
 void main() async {
-
+  WidgetsFlutterBinding.ensureInitialized(); // Required by FlutterConfig
   await FlutterConfig.loadEnvVariables();
 
   runApp(MyApp());


### PR DESCRIPTION
Without `WidgetsFlutterBinding.ensureInitialized();` in the main the app crash in runtime with:

```dart
[ERROR:flutter/lib/ui/ui_dart_state.cc(166)] Unhandled Exception: ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
#0      defaultBinaryMessenger.<anonymous closure> (package:flutter/src/services/binary_messenger.dart:93:7)
#1      defaultBinaryMessenger (package:flutter/src/services/binary_messenger.dart:106:4)
#2      MethodChannel.binaryMessenger (package:flutter/src/services/platform_channel.dart:145:62)
#3      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:151:35)
#4      MethodChannel.invokeMethod (package:flutter/src/services/platform_channel.dart:334:12)
#5      MethodChannel.invokeMapMethod (package:flutter/src/services/platform_channel.dart:361:48)
#6      FlutterConfig.loadEnvVariables (package:flutter_config/flutter_config.dart:21:24)
#7      main (package:client/main.dart:11:23)
#8      _runMainZoned.<anonymous closure>.<anonymous closure> (dart:ui/hooks.dart:233:25)
#9      _rootRun (dart:async/zone.dart:1190:13)
#10     _CustomZone.run (dart:async/zone.dart:1093:19)
#11     _runZoned (dart:async/zone.dart:1630:10)
#12     runZonedGuarded (dart:async/zone.dart:1618:12)
#13     _runMainZoned.<anonymous closure> (dart:ui/hooks.dart:225:5)
#14     _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:301:19)
#15     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:168:12)
```