### PR TITLE
Fix Nil Check Error in Ruby Dot Env Reading Script

### DIFF
--- a/ios/Classes/ReadDotEnv.rb
+++ b/ios/Classes/ReadDotEnv.rb
@@ -18,7 +18,7 @@ def read_dot_env(envs_root)
     envFilePath = "#{envs_root}.envfile"
   end
   # pick a custom env file if set
-  if File.exists?(envFilePath)
+  unless envFilePath.nil?
     puts "file exists at #{envFilePath}"
     custom_env = true
     file = File.read(envFilePath).strip


### PR DESCRIPTION
ReadDotEnv tries to see if any .envfile records exist pointing to .env files.
If there are no .envfile entries, it attempted to check for the existance of a file
at nil location.

Changed script to continue if file path exists, as all previous logic checks existance
already