### PR TITLE
Add conditional namespace to support gradle 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.byneapp.flutter_config'
+    }
+    
     compileSdkVersion 29
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,10 @@ android {
     if (project.android.hasProperty("namespace")) {
         namespace 'com.byneapp.flutter_config'
     }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     
     compileSdkVersion 29
 


### PR DESCRIPTION
A breaking change was introduced in gradle 8. You must set the namespace in the module-level build.gradle.kts file, rather than the manifest file. More info: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl

Setting it conditionally for backwards compatibility: https://github.com/flutter/flutter/issues/125621